### PR TITLE
First review

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -49,8 +49,8 @@ rule all:
         expand("results/{PROJECT}/runs/{RUN}/04-taxonomy/identity_filtered/{DATABASE}_blca_tax_table_{CUTOFF}.txt", PROJECT=PROJECT, RUN=RUN, DATABASE=DATABASE, CUTOFF=CUTOFF),
         expand("results/{PROJECT}/runs/{RUN}/06-report/taxonomy/{DATABASE}_blca_tax_table_{CUTOFF}_report.txt", PROJECT=PROJECT, RUN=RUN, DATABASE=DATABASE, CUTOFF=CUTOFF),
         expand("results/{PROJECT}/runs/{RUN}/05-dwca/Occurence_table.csv",PROJECT=PROJECT, RUN=RUN),
-        #expand("results/{PROJECT}/runs/{RUN}/06-report/{PROJECT}_{RUN}.html",PROJECT=PROJECT, RUN=RUN)
-        "./workflow/reports/RUN.html"
+        expand("results/{PROJECT}/runs/{RUN}/report.html",PROJECT=PROJECT, RUN=RUN)
+
 
 # RULES: INITIATE STRUCTURE ----------------------------------------------------------------
 
@@ -484,10 +484,9 @@ rule make_dwca:
 
 
 rule reporting:
+  conda:
+    "envs/rmd.yaml"
   output:
-#       "./results/{PROJECT}/runs/{RUN}/06-report/{PROJECT}_{RUN}.html"
-    "./workflow/reports/RUN.html"
+    "results/{PROJECT}/runs/{RUN}/report.html"
   shell:
-#    "Rscript -e 'rmarkdown::render('./workflow/scripts/Report_PacMAN_Pipeline.Rmd', output_file = path('workflow/reports/RUN.html'))'"
-#    "Rscript -e 'rmarkdown::render(""workflow/scripts/Report_PacMAN_Pipeline.Rmd"")'"
-     "Rscript -e \"rmarkdown::render('workflow/scripts/Report_PacMAN_Pipeline.Rmd', output_file = './workflow/RUN.html')\""
+    "Rscript -e \"rmarkdown::render('workflow/scripts/Report_PacMAN_Pipeline.Rmd', output_file = '../../results/{PROJECT}/runs/{RUN}/report.html')\""

--- a/workflow/envs/blca.yaml
+++ b/workflow/envs/blca.yaml
@@ -2,3 +2,4 @@ channels:
  - conda-forge
 dependencies:
  - python=3.8.8
+ - biopython=1.79

--- a/workflow/envs/dwca.yaml
+++ b/workflow/envs/dwca.yaml
@@ -3,6 +3,8 @@ channels:
  - bioconda
 dependencies:
  - r-base=4.0.3
+ - r-reshape2=1.4.4
+ - r-xml2=1.3.2
  - bioconductor-phyloseq=1.34.0
  - r-stringr=1.4.0
  - r-dplyr=1.0.7

--- a/workflow/envs/rmd.yaml
+++ b/workflow/envs/rmd.yaml
@@ -1,0 +1,6 @@
+channels:
+ - r
+dependencies:
+ - r-base=4.0.3
+ - r-rmarkdown=2.9
+ - r-here=1.0.1

--- a/workflow/scripts/Report_PacMAN_Pipeline.Rmd
+++ b/workflow/scripts/Report_PacMAN_Pipeline.Rmd
@@ -6,28 +6,19 @@ output: html_document
 ---
 
 
-
-
 ```{r}
-library('here')
-here()
-getwd()
-
+library(here)
 #![alt text here]("./results/TRIAL2/runs/ARMS_4_SAMPLES/06-report/dada2/aggregate_quality_profiles_forward.png")
-
-
 #![alt text here]("./results/TRIAL2/runs/ARMS_4_SAMPLES/06-report/dada2/aggregate_quality_profiles_forward.png")
 ```
 
 READ in config file, and build from there
 
 ```{r, echo=FALSE, out.width="49%", out.height="20%",fig.cap="caption",fig.show='hold',fig.align='center'}
-
 #here("results","TRIAL2", "runs", "ARMS_4_SAMPLES", "06-report", "dada2", "aggregate_quality_profiles_forward.png")
-knitr::include_graphics(c(here("results","TRIAL2", "runs", "ARMS_4_SAMPLES", "06-report", "dada2", "aggregate_quality_profiles_forward.png"), here("results","TRIAL2", "runs", "ARMS_4_SAMPLES", "06-report", "dada2", "aggregate_quality_profiles_reverse.png")))
+#knitr::include_graphics(c(here("results","TRIAL2", "runs", "ARMS_4_SAMPLES", "06-report", "dada2", "aggregate_quality_profiles_forward.png"), here("results","TRIAL2", "runs", "ARMS_4_SAMPLES", "06-report", "dada2", "aggregate_quality_profiles_reverse.png")))
 ```
 
 ```{r, echo=FALSE, out.width="49%", out.height="20%",fig.cap="caption",fig.show='hold',fig.align='center'}
-
-knitr::include_graphics(c(here("results","TRIAL2", "runs", "ARMS_4_SAMPLES", "06-report", "dada2", "aggregate_quality_profiles_filtered_forward.png"), here("results","TRIAL2", "runs", "ARMS_4_SAMPLES", "06-report", "dada2", "aggregate_quality_profiles_filtered_reverse.png")))
+#knitr::include_graphics(c(here("results","TRIAL2", "runs", "ARMS_4_SAMPLES", "06-report", "dada2", "aggregate_quality_profiles_filtered_forward.png"), here("results","TRIAL2", "runs", "ARMS_4_SAMPLES", "06-report", "dada2", "aggregate_quality_profiles_filtered_reverse.png")))
 ```


### PR DESCRIPTION
This adds dependencies to a few environments, and sets up an environment for the rmarkdown report. The report is written to `results` instead of `workflow`. Code in the report has been commented out to be able to run the entire pipeline without errors. I suggest to pass `PROJECT` and `RUN` as parameters to the render function, see https://rmarkdown.rstudio.com/lesson-6.html.