### PR TITLE
Fixes

### DIFF
--- a/config/config-pacman.yaml
+++ b/config/config-pacman.yaml
@@ -104,6 +104,9 @@ DADA2:
     pool: FALSE
     priors: ""
 
+#In case the reads are not overlapping, but paired, there are two choices.
+#1. Skip the merging with include: FALSE, ASV's will be inferred from the forw and reverse reads separately
+#2. jusConcatenate, concantenates the reads with a number of NNNNs in between. This may complicate the taxonomic assignment step. 
   mergePairs:
     include: TRUE
     minOverlap: 12

--- a/config/config-pacman.yaml
+++ b/config/config-pacman.yaml
@@ -71,7 +71,7 @@ DADA2:
     id.field: NULL
     compress: TRUE
     multithread: TRUE
-    n: 100000
+    num: 100000
     OMP: TRUE
     verbose: FALSE
 
@@ -96,13 +96,13 @@ DADA2:
     nominalQ: TRUE
 
   derepFastq:
-    n: 1e6
+    num: 1e6
 
   dada:
     errorEstimationFunction: loessErrfun
     selfConsist: FALSE
     pool: FALSE
-    priors: NULL
+    priors: ""
 
   mergePairs:
     include: TRUE

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -1,7 +1,7 @@
 """
 Pacman-pipeline
 Authors: Saara Suominen,
-Last update: 24/06/2021
+Last update: 03/12/2021
 """
 import pandas as pd
 import sys
@@ -217,7 +217,7 @@ rule cutadapt_unpaired:
         -a {config[cutadapt][rc_reverse_primer]} \
         -o {output.o1} \
         {input.u1} \
-        {config[cutadapt][se_extra_params]} \
+        --minimum-length 1 {config[cutadapt][se_extra_params]} \
         1> {log.f1}; \
         cutadapt \
         -g {config[cutadapt][reverse_primer]} \
@@ -233,7 +233,7 @@ rule cutadapt_unpaired:
 
 # RULES: ASV INFERENCE WITH DADA2----------------------------------------------------------------
 
-#In this section we run the dada2 pipeline
+#In this section we run the dada2 pipeline, both paired and single reads are analysed and added to the final tables.
 
 if config["meta"]["sequencing"]["lib_layout"] == "Paired":
     rule dada2_filter:
@@ -252,7 +252,7 @@ if config["meta"]["sequencing"]["lib_layout"] == "Paired":
         conda:
             "envs/dada2.yaml"
         shell:
-            "Rscript ./workflow/scripts/Dada2_FilterAndTrim.R \
+            "Rscript ./workflow/scripts/Dada2_FilterAndTrim_combined.R \
             results/{config[PROJECT]}/runs/{config[RUN]}/ \
             "+config_path+" \
             {input.f1}"
@@ -274,7 +274,7 @@ if config["meta"]["sequencing"]["lib_layout"] == "Paired":
         conda:
             "envs/dada2.yaml"
         shell:
-            "Rscript ./workflow/scripts/Dada2_ASVInference.R \
+            "Rscript ./workflow/scripts/Dada2_ASVInference_Single.R \
             results/{config[PROJECT]}/runs/{config[RUN]}/ \
             "+config_path+" \
             {input.FiltF}"

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -234,95 +234,50 @@ rule cutadapt_unpaired:
 # RULES: ASV INFERENCE WITH DADA2----------------------------------------------------------------
 
 #In this section we run the dada2 pipeline
-#Should this be divided into a few separate parts? so that each part can be modified in the configfile if needed.
-#Be sure to record how many reads have passed the filters before this step! (should all be in the log files of the other steps, which still need to be saved)
-#Still need to add all the params to the configfile and to the script
 
-rule dada2_filter:
-  input:
-    #files = expand("{PROJECT}/runs/{RUN}/02-cutadapt/{samples}/", PROJECT=PROJECT, RUN=RUN, samples=samples),
-    f1 = expand("results/{PROJECT}/runs/{RUN}/02-cutadapt/{samples}/{samples}_1P.fastq.gz",
-                PROJECT=PROJECT, RUN=RUN, samples=samples),
-    #f2 = expand("{PROJECT}/runs/{RUN}/02-cutadapt/{samples}/{samples}_2P.fastq.gz", PROJECT=PROJECT, RUN=RUN, samples=samples),
-  output:
-    FiltF = expand("results/{PROJECT}/runs/{RUN}/03-dada2/filtered/{samples}/{samples}_1P.fastq.gz",
-                   PROJECT=PROJECT, RUN=RUN, samples=samples),
-    FiltR = expand("results/{PROJECT}/runs/{RUN}/03-dada2/filtered/{samples}/{samples}_2P.fastq.gz",
-                   PROJECT=PROJECT, RUN=RUN, samples=samples),
-    #directory(expand("{PROJECT}/runs/{RUN}/dada2/filtered/{samples}/"), PROJECT=PROJECT, RUN=RUN, samples=samples),
-    #stats="{PROJECT}/runs/{RUN}/dada2/dada2_filtering_stats.txt",
-  conda:
-    "envs/dada2.yaml"
-  shell:
-    "Rscript ./workflow/scripts/Dada2_FilterAndTrim.R \
-    results/{config[PROJECT]}/runs/{config[RUN]}/ \
-    {config[DADA2][filterAndTrim][Trunc_len_f]} \
-    {config[DADA2][filterAndTrim][Trunc_len_r]} \
-    {config[DADA2][filterAndTrim][TruncQ]} \
-    {config[DADA2][filterAndTrim][Trim_right]} \
-    {config[DADA2][filterAndTrim][Trim_left]} \
-    {config[DADA2][filterAndTrim][maxLen]} \
-    {config[DADA2][filterAndTrim][minLen]} \
-    {config[DADA2][filterAndTrim][maxN]} \
-    {config[DADA2][filterAndTrim][minQ]} \
-    {config[DADA2][filterAndTrim][MaxEE]} \
-    {config[DADA2][filterAndTrim][Rm.phix]} \
-    {config[DADA2][filterAndTrim][orient.fwd]} \
-    {config[DADA2][filterAndTrim][matchIDs]} \
-    {config[DADA2][filterAndTrim][id.sep]} \
-    {config[DADA2][filterAndTrim][id.field]} \
-    {config[DADA2][filterAndTrim][compress]} \
-    {config[DADA2][filterAndTrim][multithread]} \
-    {config[DADA2][filterAndTrim][n]} \
-    {config[DADA2][filterAndTrim][OMP]} \
-    {config[DADA2][filterAndTrim][verbose]} \
-    {input.f1}"
+if config["meta"]["sequencing"]["lib_layout"] == "Paired":
+    rule dada2_filter:
+        input:
+            #files = expand("{PROJECT}/runs/{RUN}/02-cutadapt/{samples}/", PROJECT=PROJECT, RUN=RUN, samples=samples),
+            f1 = expand("results/{PROJECT}/runs/{RUN}/02-cutadapt/{samples}/{samples}_1P.fastq.gz",
+                        PROJECT=PROJECT, RUN=RUN, samples=samples),
+            #f2 = expand("{PROJECT}/runs/{RUN}/02-cutadapt/{samples}/{samples}_2P.fastq.gz", PROJECT=PROJECT, RUN=RUN, samples=samples),
+        output:
+            FiltF = expand("results/{PROJECT}/runs/{RUN}/03-dada2/filtered/{samples}/{samples}_1P.fastq.gz",
+                           PROJECT=PROJECT, RUN=RUN, samples=samples),
+            FiltR = expand("results/{PROJECT}/runs/{RUN}/03-dada2/filtered/{samples}/{samples}_2P.fastq.gz",
+                           PROJECT=PROJECT, RUN=RUN, samples=samples),
+            #directory(expand("{PROJECT}/runs/{RUN}/dada2/filtered/{samples}/"), PROJECT=PROJECT, RUN=RUN, samples=samples),
+            #stats="{PROJECT}/runs/{RUN}/dada2/dada2_filtering_stats.txt",
+        conda:
+            "envs/dada2.yaml"
+        shell:
+            "Rscript ./workflow/scripts/Dada2_FilterAndTrim.R \
+            results/{config[PROJECT]}/runs/{config[RUN]}/ \
+            "+config_path+" \
+            {input.f1}"
 
-
-rule dada2_ASV:
-  input:
-    FiltF = expand("results/{PROJECT}/runs/{RUN}/03-dada2/filtered/{samples}/{samples}_1P.fastq.gz",
-                   PROJECT=PROJECT, RUN=RUN, samples=samples),
-    FiltR = expand("results/{PROJECT}/runs/{RUN}/03-dada2/filtered/{samples}/{samples}_2P.fastq.gz",
-                   PROJECT=PROJECT, RUN=RUN, samples=samples),
-  output:
-    #o1 = expand("results/{PROJECT}/runs/{RUN}/03-dada2/dada2_stats.txt", PROJECT=PROJECT, RUN=RUN),
-    #o2 = expand("results/{PROJECT}/runs/{RUN}/03-dada2/seqtab-nochim.txt", PROJECT=PROJECT, RUN=RUN),
-    #o3 = expand("results/{PROJECT}/runs/{RUN}/03-dada2/rep-seqs.fna", PROJECT=PROJECT, RUN=RUN),
-    o2 = "results/{PROJECT}/runs/{RUN}/03-dada2/seqtab-nochim.txt",
-    o3 = "results/{PROJECT}/runs/{RUN}/03-dada2/rep-seqs.fna",
-  log:
-    o1 = "results/{PROJECT}/runs/{RUN}/06-report/dada2/dada2_stats.txt",
-  conda:
-    "envs/dada2.yaml"
-  shell:
-    "Rscript ./workflow/scripts/Dada2_ASVInference.R \
-    results/{config[PROJECT]}/runs/{config[RUN]}/ \
-    {config[DADA2][learnERRORS][multithread]} \
-    {config[DADA2][learnERRORS][nbases]} \
-    {config[DADA2][learnERRORS][randomize]} \
-    {config[DADA2][learnERRORS][MAX_CONSIST]} \
-    {config[DADA2][learnERRORS][OMEGA_C]} \
-    {config[DADA2][learnERRORS][verbose]} \
-    {config[DADA2][plotERRORS][nti]} \
-    {config[DADA2][plotERRORS][ntj]} \
-    {config[DADA2][plotERRORS][obs]} \
-    {config[DADA2][plotERRORS][err_out]} \
-    {config[DADA2][plotERRORS][err_in]} \
-    {config[DADA2][plotERRORS][nominalQ]} \
-    {config[DADA2][derepFastq][n]} \
-    {config[DADA2][dada][selfConsist]} \
-    {config[DADA2][dada][pool]} \
-    {config[DADA2][dada][priors]} \
-    {config[DADA2][mergePairs][include]} \
-    {config[DADA2][mergePairs][minOverlap]} \
-    {config[DADA2][mergePairs][maxMismatch]} \
-    {config[DADA2][mergePairs][returnRejects]} \
-    {config[DADA2][mergePairs][propagateCol]} \
-    {config[DADA2][mergePairs][justConcatenate]} \
-    {config[DADA2][mergePairs][trimOverhang]} \
-    {config[DADA2][removeBimeraDenovo][method]} \
-    {input.FiltF}"
+    rule dada2_ASV:
+        input:
+            FiltF = expand("results/{PROJECT}/runs/{RUN}/03-dada2/filtered/{samples}/{samples}_1P.fastq.gz",
+                           PROJECT=PROJECT, RUN=RUN, samples=samples),
+            FiltR = expand("results/{PROJECT}/runs/{RUN}/03-dada2/filtered/{samples}/{samples}_2P.fastq.gz",
+                           PROJECT=PROJECT, RUN=RUN, samples=samples),
+        output:
+            #o1 = expand("results/{PROJECT}/runs/{RUN}/03-dada2/dada2_stats.txt", PROJECT=PROJECT, RUN=RUN),
+            #o2 = expand("results/{PROJECT}/runs/{RUN}/03-dada2/seqtab-nochim.txt", PROJECT=PROJECT, RUN=RUN),
+            #o3 = expand("results/{PROJECT}/runs/{RUN}/03-dada2/rep-seqs.fna", PROJECT=PROJECT, RUN=RUN),
+            o2 = "results/{PROJECT}/runs/{RUN}/03-dada2/seqtab-nochim.txt",
+            o3 = "results/{PROJECT}/runs/{RUN}/03-dada2/rep-seqs.fna",
+        log:
+            o1 = "results/{PROJECT}/runs/{RUN}/06-report/dada2/dada2_stats.txt",
+        conda:
+            "envs/dada2.yaml"
+        shell:
+            "Rscript ./workflow/scripts/Dada2_ASVInference.R \
+            results/{config[PROJECT]}/runs/{config[RUN]}/ \
+            "+config_path+" \
+            {input.FiltF}"
 
 
 # RULES: TAXONOMIC ASSIGNMENT ----------------------------------------------------------------

--- a/workflow/envs/dada2.yaml
+++ b/workflow/envs/dada2.yaml
@@ -8,3 +8,4 @@ dependencies:
  - bioconductor-dada2=1.18.0
  - r-ggplot2=3.3.3
  - r-yaml=2.2.1
+ - r-dplyr=1.0.7

--- a/workflow/envs/dada2.yaml
+++ b/workflow/envs/dada2.yaml
@@ -7,3 +7,4 @@ dependencies:
  - r-reshape2=1.4.4
  - bioconductor-dada2=1.18.0
  - r-ggplot2=3.3.3
+ - r-yaml=2.2.1

--- a/workflow/scripts/Dada2_ASVInference.R
+++ b/workflow/scripts/Dada2_ASVInference.R
@@ -40,7 +40,7 @@ errF <- learnErrors(filtFs, multithread = config$DADA2$learnERRORS$multithread,
   MAX_CONSIST = as.numeric(config$DADA2$learnERRORS$MAX_CONSIST), OMEGA_C = as.numeric(config$DADA2$learnERRORS$OMEGA_C),
   verbose = config$DADA2$learnERRORS$verbose)
 
-errR <- learnErrors(filtFs, multithread = config$DADA2$learnERRORS$multithread,
+errR <- learnErrors(filtRs, multithread = config$DADA2$learnERRORS$multithread,
   nbases = as.numeric(config$DADA2$learnERRORS$nbases), randomize = config$DADA2$learnERRORS$randomize,
   MAX_CONSIST = as.numeric(config$DADA2$learnERRORS$MAX_CONSIST), OMEGA_C = as.numeric(config$DADA2$learnERRORS$OMEGA_C),
   verbose = config$DADA2$learnERRORS$verbose)

--- a/workflow/scripts/Dada2_ASVInference_Single.R
+++ b/workflow/scripts/Dada2_ASVInference_Single.R
@@ -1,0 +1,298 @@
+#####
+# Dada2 Step 2: ASV inference
+
+# @author: Saara Suominen
+# last major modification on the 8.12.2021
+
+#input=snakemake@input[[1]] Not working with the shell command, files are read as {input}
+library(plyr)
+library(dplyr)
+library(yaml)
+library(dada2)
+library(Biostrings)
+library(ggplot2)
+
+
+args <- commandArgs(trailingOnly = T)
+config=read_yaml(args[2])
+
+# Set the different paths for all the supplied libraries
+#NOTICE: only forward files given as input
+filtFs <- args[3:length(args)]
+filtFs_single=gsub("_1P", "_1U", filtFs)
+
+filtRs <- gsub("_1P", "_2P", filtFs)
+filtRs_single <- gsub("_2P", "_2U", filtRs)
+
+outpath <- args[1]
+
+
+# The parameters nti/ntj, need the chosen nucleotides in a vector format:
+nti <- strsplit(config$DADA2$plotERRORS$nti, "")[[1]]
+if (length(nti) == 0) {
+  message("Default value given to nti, all nucleotide transitions will be shown in the error plot")
+  nti <- c("A", "C", "G", "T")
+}
+
+ntj <- strsplit(config$DADA2$plotERRORS$ntj, "")[[1]]
+if (length(nti) == 0) {
+  message("Default value given to ntj, all nucleotide transitions will be shown in the error plot")
+  ntj <- c("A", "C", "G", "T")
+}
+
+
+# Get sample names
+sample.names <- gsub("_1P.fastq.gz", "", basename(filtFs))
+message(paste0("Sample ", sample.names, " will be analyzed", collapse = "\n"))
+
+# assign names to files
+names(filtFs) <- sample.names
+names(filtRs) <- sample.names
+names(filtFs_single) <- sample.names
+names(filtRs_single) <- sample.names
+
+allfiles=list(filtFs, filtRs, filtFs_single, filtRs_single)
+names(allfiles)=c("filtFs", "filtRs", "filtFs_single", "filtRs_single")
+errs=list()
+dereps=list()
+dadas=list()
+seqtab=list()
+
+#Loop through all file types (forward, reverse, unpaired forward, unpaired reverse) for learning errors and dereplicating
+for (i in 1:4){
+
+if (any(file.exists(allfiles[[i]]))) {
+
+  message(paste("learning error rates of files:", i, ": (1) forward paired (2) reverse paired (3) forward single and (4) reverse single " , sep=" "))
+
+  #print(allfiles[[i]][file.exists(allfiles[[i]])])
+
+  errs[[i]] <- learnErrors(allfiles[[i]][file.exists(allfiles[[i]])],
+                           multithread = config$DADA2$learnERRORS$multithread,
+                           nbases = as.numeric(config$DADA2$learnERRORS$nbases),
+                           randomize = config$DADA2$learnERRORS$randomize,
+                           MAX_CONSIST = as.numeric(config$DADA2$learnERRORS$MAX_CONSIST),
+                           OMEGA_C = as.numeric(config$DADA2$learnERRORS$OMEGA_C),
+                           verbose = config$DADA2$learnERRORS$verbose)
+
+  message("Making error estimation plots of reads")
+  png(filename = paste0(outpath, "06-report/dada2/error_profile_", names(allfiles)[i], ".png"))
+      plotErrors(errs[[i]],
+      nti = nti,
+      ntj = ntj,
+      obs = config$DADA2$plotERRORS$obs,
+      err_out = config$DADA2$plotERRORS$err_out,
+      err_in = config$DADA2$plotERRORS$err_in,
+      nominalQ = config$DADA2$plotERRORS$nominalQ)
+  dev.off()
+
+  message("Running dereplication of reads")
+  dereps[[i]] <- derepFastq(allfiles[[i]][file.exists(allfiles[[i]])],
+                            n = as.numeric(config$DADA2$derepFastq$num),
+                            config$DADA2$learnERRORS$verbose)
+
+  message("Running dada on reads")
+  dadas[[i]] <- dada(dereps[[i]],
+                     errs[[i]],
+                     selfConsist = config$DADA2$dada$selfConsist,
+                     pool = config$DADA2$dada$pool,
+                     priors = config$DADA2$dada$priors,
+                     multithread = config$DADA2$learnERRORS$multithread,
+                     verbose = config$DADA2$learnERRORS$verbose)
+
+#If no files found for the paired reads (should not be the case!)
+} else if (!grepl("single", names(allfiles)[i])) {
+
+  message("Error: no paired reads to process")
+  stop()
+
+#If no files found for the unpaired reads, continue with the workflow
+#It has to be made sure in the snakefile that this step is run despite not requiring output files
+} else {
+
+  message("No further unpaired reads to process")
+
+}
+}
+
+
+
+#Merge forward and reverse paired reads
+message("attempting merge")
+
+#Define function for merging and formatting seqtabs: next steps require an integer matrix
+merge_format_seqtab=function(seqtab1, seqtab2){
+  seqtab_new <- merge(seqtab1, seqtab2, by=0, all=TRUE)
+  rownames(seqtab_new)=seqtab_new$Row.names
+  seqtab_new=subset(seqtab_new, select = -Row.names)
+  seqtab_new[is.na(seqtab_new)] <- 0
+  seqtab_new=data.matrix(seqtab_new)
+  mode(seqtab_new)<-'integer'
+  return(seqtab_new)
+}
+
+if (config$DADA2$mergePairs$include) {
+  message("merging pairs")
+  mergers <- mergePairs(dadas[[1]],
+                        dereps[[1]],
+                        dadas[[2]],
+                        dereps[[2]],
+                        minOverlap = as.numeric(config$DADA2$mergePairs$minOverlap),
+                        maxMismatch = as.numeric(config$DADA2$mergePairs$maxMismatch),
+                        returnRejects = config$DADA2$mergePairs$returnRejects,
+                        propagateCol = config$DADA2$mergePairs$propagateCol,
+                        justConcatenate = config$DADA2$mergePairs$justConcatenate,
+                        trimOverhang = config$DADA2$mergePairs$trimOverhang,
+                        verbose = config$DADA2$learnERRORS$verbose)
+
+seqtab <- makeSequenceTable(mergers)
+
+  #When merging is done with returnRejects=TRUE, the abundance of the rejected merges is returned, but not the sequence
+  #We want to collect also these single sequences and add them to the seqtab (to avoid loosing ANY data)
+  if (config$DADA2$mergePairs$returnRejects==TRUE){
+    unmerged_f=list()
+    unmerged_r=list()
+    for (i in 1:length(sample.names)){
+      unmerged_f[[i]]=ldply(dadas[[1]][[sample.names[i]]]$denoised[mergers[[sample.names[i]]]$forward[!mergers[[sample.names[i]]]$accept]])
+      unmerged_r[[i]]=ldply(dadas[[2]][[sample.names[i]]]$denoised[mergers[[sample.names[i]]]$reverse[!mergers[[sample.names[i]]]$accept]])
+      #Here for the rejected reads (!merger$sample$accept) the indices are collected (merger$sample$forward, merger$sample$reverse)
+      #The sequences are sourced from the original dada-file (dadaF$sample$denoised, dadaR$sample$denoised)
+      #Some of the sequences are tried for merging multiple times?
+      #Abundances for these reads is taken from the merged abundances.
+      #Now the abundances are therefore 2x, anacapa concatenates the sequences for this table and separates them later again, but I am not sure about this.
+      colnames(unmerged_f[[i]])=c("sequence", "abundance")
+      unmerged_f[[i]]$abundance=mergers[[sample.names[i]]]$abundance[!mergers[[sample.names[i]]]$accept]/2
+      colnames(unmerged_r[[i]])=c("sequence", "abundance")
+      unmerged_r[[i]]$abundance=mergers[[sample.names[i]]]$abundance[!mergers[[sample.names[i]]]$accept]/2
+    }
+    names(unmerged_f)=sample.names
+    names(unmerged_r)=sample.names
+
+    #Combine forward and reverse sequences to one table
+    seqtab1 <- makeSequenceTable(unmerged_f)
+    seqtab2 <- makeSequenceTable(unmerged_r)
+
+    #reverse complement reverse reads so that the following taxonomic assignment will work optimally.
+    colnames(seqtab2)<- sapply(sapply(sapply(colnames(seqtab2), DNAString), reverseComplement), toString)
+    seqtab_unmerged <- cbind(seqtab1, seqtab2)
+
+    #The merged returnrejects=T seqtab also contains a column with an empty header,
+    #This is all rejected (non-merged) abundances combined.
+    #This column messes with future steps, so we want to remove it.
+    #We have instead collected the abundances of the unmerged reads to add to the table with sequences.
+    seqtab <- seqtab[,-which(colnames(seqtab)=="")]
+
+    #Merge with paired reads and format for the next steps (integer matrix)
+    seqtab <- merge_format_seqtab(seqtab, seqtab_unmerged)
+
+  }} else {
+
+  message("no merging of paired reads")
+  #Combine forward and reverse sequences to one table
+  seqtab1 <- makeSequenceTable(dadas[[1]])
+  seqtab2 <- makeSequenceTable(dadas[[2]])
+  #reverse complement reverse reads so that the following taxonomic assignment will work optimally.
+  colnames(seqtab2)<- sapply(sapply(sapply(colnames(seqtab2), DNAString), reverseComplement), toString)
+  seqtab <- cbind(seqtab1, seqtab2)
+
+}
+
+
+#Add ASVs from single reads to full table, and format table to the right format to continue with the pipeline
+#It has to be an integer matrix with samples as rownames and sequences as column names
+if (any(file.exists(allfiles[[3]]))) {
+  message("Adding ASVs from unpaired forward reads to ASV-table")
+  seqtab3 <- makeSequenceTable(dadas[[3]])
+  seqtab <- merge_format_seqtab(seqtab, seqtab3)
+}
+
+
+if (any(file.exists(allfiles[[4]]))) {
+  message("Adding ASVs from unpaired reverse reads to ASV-table")
+  seqtab4 <- makeSequenceTable(dadas[[4]])
+  #Here also the sequences from the reverse reads are reverse complemented before they are added to the sequence table
+  colnames(seqtab4)<- sapply(sapply(sapply(colnames(seqtab4), DNAString), reverseComplement), toString)
+  seqtab <- merge_format_seqtab(seqtab, seqtab4)
+}
+
+
+#Chimeras removed from the full combined table as per:https://github.com/benjjneb/dada2/issues/1235:
+#We think the best way (in most cases, using current common techs -- such is the challenge of recommendations) is to combine the tables from multiple runs and then remove chimeras on that combined table.
+#Look into details of how chimera removal is done to understand if this is smart
+#In their case they are looking at equal length reads, possibly the single reads and paired reads should not be combined for chimera removal?
+
+message("removing chimeras")
+seqtab.nochim <- removeBimeraDenovo(seqtab,
+                                    method = config$DADA2$removeBimeraDenovo$method,
+                                    multithread = config$DADA2$learnERRORS$multithread,
+                                    verbose = config$DADA2$learnERRORS$verbose)
+
+print(dim(seqtab.nochim))
+# ASVs denominated by the actual sequence, we want to simplify the names.
+new.names <- c(paste("asv.", 1:length(colnames(seqtab.nochim)), sep = ""))
+message(head(new.names))
+
+# Save fasta, before changing names in the seqtab table
+message("Making fasta table")
+uniquesToFasta(seqtab.nochim, fout = paste0(outpath, "03-dada2/rep-seqs.fna"), ids = new.names)
+
+# Finally, change names in otu table
+message("Changing sequence names")
+colnames(seqtab.nochim) <- new.names
+
+#this show sequence length distributions (see if you should include this)
+#seq_hist <- table(nchar(getSequences(seqtab)))
+#fname_seqh <- paste(args[6],"seq_hist.txt",sep="")
+#write.table(seq_hist, file = fname_seqh  , sep = "\t", quote=FALSE, col.names = FALSE)
+
+# Collect results of how many reads are available at each step in a table:
+getN <- function(x) sum(getUniques(x))
+
+#Make a table with all information on the reads retained from the run, if paired reads were merged:
+message("Making summary table")
+if (config$DADA2$mergePairs$include) {
+  track <- cbind(sapply(dadas[[1]], getN), sapply(dadas[[2]], getN), sapply(mergers, getN), rowSums(seqtab.nochim), rowSums(seqtab.nochim != 0))
+  colnames(track) <- c("denoisedF", "denoisedR", "merged", "nonchim", "ASVs")
+#If paired reads were not merged:
+} else {
+  track <- cbind(sapply(dadas[[1]], getN), sapply(dadas[[2]], getN), rowSums(seqtab.nochim), rowSums(seqtab.nochim != 0))
+  colnames(track) <- c("denoisedF", "denoisedR", "nonchim", "ASVs")
+}
+
+#Add also information on the reads that came from possibly evaluated single reads
+if (any(file.exists(allfiles[[3]]))) {
+  message("Adding info from unpaired forward reads to the summary table")
+  denoisedF_single=sapply(dadas[[3]], getN)
+  track=merge(track, data.frame(denoisedF_single), by=0, all = TRUE)
+  rownames(track)=track$Row.names
+  track=subset(track, select = -Row.names)
+  #reorder columns:
+  track <- track %>% relocate(denoisedF_single, .before = nonchim)
+}
+
+if (any(file.exists(allfiles[[4]]))) {
+  message("Adding info from unpaired reverse reads to the summary table")
+  denoisedR_single=sapply(dadas[[4]], getN)
+  track=merge(track, data.frame(denoisedR_single), by=0, all = TRUE)
+  rownames(track)=track$Row.names
+  track=subset(track, select = -Row.names)
+  track <- track %>% relocate(denoisedR_single, .before = nonchim)
+}
+
+rownames(track)
+rownames(track) <- sample.names
+message(track)
+
+# Read results of filtering step and append the results of ASV step:
+out <- read.table(paste0(outpath, "06-report/dada2/dada2_filtering_stats.txt"), header = TRUE)
+#print(out)
+track <- cbind(out, track)
+
+# Write output tables of reads and the otu_table:
+write.table(track, paste0(outpath, "06-report/dada2/dada2_stats.txt"), row.names = TRUE, col.names = TRUE, quote = FALSE)
+write.table(t(seqtab.nochim), paste0(outpath,"03-dada2/seqtab-nochim.txt"), sep = "\t", row.names = TRUE, col.names = NA, quote = FALSE)
+
+# Fix for https://github.com/tidyverse/ggplot2/issues/2787
+if (file.exists("Rplots.pdf")) {
+  file.remove("Rplots.pdf")
+}

--- a/workflow/scripts/Dada2_FilterAndTrim.R
+++ b/workflow/scripts/Dada2_FilterAndTrim.R
@@ -6,67 +6,26 @@
 # modified by Saara Suominen on the 15.6.2021
 
 #input=snakemake@input[[1]] Not working with the shell command, files are read as {input}
-
+library(yaml)
 library(dada2)
 #library(Biostrings)
 library(ggplot2)
 
 args <- commandArgs(trailingOnly = TRUE)
-
 #Add all arguments for dada2 parameters from configfile!
-#args[1]... = outpath for dada2 files (project/run/dada2/)
-truncLen_F <-    as.numeric(args[2])
-truncLen_R <-    as.numeric(args[3])
-truncQ <-        as.numeric(args[4])
-trimRight <-     as.numeric(args[5])
-trimLeft <-      as.numeric(args[6])
-maxLen <-        as.numeric(args[7])
-minLen <-        as.numeric(args[8])
-maxN <-          as.numeric(args[9])
-minQ <-          as.numeric(args[10])
-maxEE <-         as.numeric(args[11])
-rm.phix <-       as.logical(args[12])
-orient.fwd <-    if (args[13] == "None") NULL else args[13]
-matchIDs <-      as.logical(args[14])
-id.sep <-        args[15]
-id.field <-      if (args[16] == "None") NULL else args[16]
-compress <-      as.logical(args[17])
-#args[18]...= multithread]} \
-n <-             as.numeric(args[19])
-OMP <-           as.logical(args[20])
-verbose <-       as.logical(args[21])
-#args[22:n]...= input.files}
-
-#Multithread can either be logical or a numeric: probably will be False and True..
-if (args[18] == "FALSE" | args[18] == "TRUE" | args[18] == "T" | args[18] == "F" | args[18] == "False" | args[18] == "True") {
-  multithread <- as.logical(args[18])
-} else {
-  multithread <- as.numeric(args[18])
-}
-
-#print(args[1:22])
+config=read_yaml(args[2])
 
 #Set the different paths for all the supplied libraries
-paths <- args[22:length(args)]
+paths <- args[3:length(args)]
 #print(paths)
 
 outpath <- args[1]
 #print(outpath)
 
-#List files
-#filesForw <- sort(list.files(paths, pattern="_1P.fastq.gz", full.names = TRUE))
-#filesRev <- sort(list.files(paths, pattern="_2P.fastq.gz", full.names = TRUE))
-#filesForw <- gsub("//", "/", filesForw)
-#filesRev <- gsub("//", "/", filesRev)
-#print(filesForw)
-#print(filesRev)
-
 #Set the different paths for all the supplied libraries
 #NOTICE: only forward files given as input
 filesForw <- paths
-#print(filtFs)
 filesRev <- gsub("_1P", "_2P", filesForw)
-#print(filtRs)
 
 #Get sample names
 sample.names <- gsub("_1P.fastq.gz", "", basename(filesForw))
@@ -126,15 +85,18 @@ names(filtFs) <- sample.names
 names(filtRs) <- sample.names
 
 out <- filterAndTrim(filesForw, filtFs, filesRev, filtRs,
-  truncLen = c(truncLen_F,truncLen_R),truncQ=truncQ,
-  trimRight = trimRight, trimLeft = trimLeft,
-  maxLen = maxLen, minLen = minLen,
-  maxN = maxN, minQ = minQ, maxEE = maxEE,
-  rm.phix = rm.phix, orient.fwd = orient.fwd,
-  matchIDs = matchIDs, id.sep = id.sep, id.field = id.field,
-  compress = compress, multithread = multithread,
-  n = n, OMP = OMP,
-  verbose = verbose
+  truncLen = c(config$DADA2$filterAndTrim$Trunc_len_f,config$DADA2$filterAndTrim$Trunc_len_r),
+  truncQ=config$DADA2$filterAndTrim$TruncQ,
+  trimRight = config$DADA2$filterAndTrim$Trim_right, trimLeft = config$DADA2$filterAndTrim$Trim_left,
+  maxLen = config$DADA2$filterAndTrim$maxLen, minLen = config$DADA2$filterAndTrim$minLen,
+  maxN = config$DADA2$filterAndTrim$maxN, minQ = config$DADA2$filterAndTrim$minQ,
+  maxEE = config$DADA2$filterAndTrim$MaxEE,
+  rm.phix = config$DADA2$filterAndTrim$Rm.phix, orient.fwd = config$DADA2$filterAndTrim$orient.fwd,
+  matchIDs = config$DADA2$filterAndTrim$matchIDs, id.sep = config$DADA2$filterAndTrim$id.sep,
+  id.field = config$DADA2$filterAndTrim$id.field,
+  compress = config$DADA2$filterAndTrim$compress, multithread = config$DADA2$filterAndTrim$multithread,
+  n = config$DADA2$filterAndTrim$num, OMP = config$DADA2$filterAndTrim$OMP,
+  verbose = config$DADA2$filterAndTrim$verbose
 )
 
 #Write out to save the effect of filtering on the reads:

--- a/workflow/scripts/Dada2_FilterAndTrim_combined.R
+++ b/workflow/scripts/Dada2_FilterAndTrim_combined.R
@@ -1,0 +1,283 @@
+#####
+# Dada2 Step 1: filter and trim
+#
+# @author: J. Engelmann
+# @author: A. ABdala
+# modified by Saara Suominen on the 15.6.2021
+
+#input=snakemake@input[[1]] Not working with the shell command, files are read as {input}
+library(yaml)
+library(dada2)
+#library(Biostrings)
+library(ggplot2)
+
+args <- commandArgs(trailingOnly = TRUE)
+#Add all arguments for dada2 parameters from configfile!
+config=read_yaml(args[2])
+
+#Set the different paths for all the supplied libraries
+paths <- args[3:length(args)]
+#print(paths)
+
+outpath <- args[1]
+#print(outpath)
+
+#Set the different paths for all the supplied libraries
+#NOTICE: only forward files given as input
+filesForw <- paths
+filesRev <- gsub("_1P", "_2P", filesForw)
+
+filesForw_single <- gsub("_1P", "_1U", filesForw)
+filesRev_single <- gsub("_1P", "_2U", filesForw)
+
+
+#Get sample names
+#sample.names <- gsub("_1P.fastq.gz", "", basename(filesForw))
+#message(paste("Sample", sample.names, "will be analysed", collapse = "\n"))
+sample.names=list()
+
+#Make folder for quality plots, and report
+dir.create(paste0(outpath, "03-dada2/quality"), recursive = TRUE)
+dir.create(paste0(outpath,"06-report/dada2/"))
+
+allfiles=list(filesForw, filesRev, filesForw_single, filesRev_single)
+names(allfiles)=c("filesForw", "filesRev", "filesForw_single", "filesRev_single")
+files_exist=list()
+filts=list()
+quals=list()
+
+#loop through 1. forward paired, 2. reverse paired 3. forward single 4. reverse single reads
+#First check that files are not empty (cutadapt returns empty files for those that don't pass any filters.)
+message("Analyse different files group separately")
+
+for (i in 1:4) {
+
+  message("Check that files are not empty")
+
+  files_loop=c()
+  #files_exist[[i]]=c()
+
+  for (j in 1:length(allfiles[[i]])) {
+  info = file.info(allfiles[[i]][j])
+  notempty = rownames(info[info$size > 20, ]) #20 is the size of an empty .gz file
+  files_loop=c(files_loop, notempty)
+  #files_exist[[i]]=c(files_exist[[i]], notempty)
+  }
+
+files_exist[[i]]=files_loop
+#print(files_exist[[i]])
+
+if (length(files_exist[[i]]!=0)) {
+  message(paste("making quality plots of raw reads:", i, ": (1) forward paired (2) reverse paired (3) forward single and (4) reverse single " , sep=" "))
+
+  sample.names[[i]] <- gsub("_1P.fastq.gz", "", basename(files_exist[[i]]))
+  sample.names[[i]] <- gsub("_2P.fastq.gz", "", sample.names[[i]])
+  sample.names[[i]] <- gsub("_1U.fastq.gz", "", sample.names[[i]])
+  sample.names[[i]] <- gsub("_2U.fastq.gz", "", sample.names[[i]])
+
+  message(paste(names(allfiles)[i], "reads of sample", sample.names[[i]], "will be analysed", collapse = "\n"))
+
+  quals[[i]] <- gsub("02-cutadapt/", "03-dada2/quality/", files_exist[[i]])
+  quals[[i]] <- gsub(".fastq.gz", ".png", quals[[i]])
+
+  plot_list<- list()
+  message("Making quality plots")
+  for (j in 1:length(quals[[i]])) {
+    dir.create(dirname(quals[[i]][j]), showWarnings = FALSE)
+    p <- plotQualityProfile(files_exist[[i]][j])
+    ggsave(quals[[i]][j], plot = p, dpi = 150, width = 10, height = 10, units = "cm")
+  }
+
+  #Make aggregate plot of all reads
+  print(plotQualityProfile(files_exist[[i]], aggregate = T))
+  ggsave(paste0(outpath,"06-report/dada2/aggregate_quality_profiles_", names(allfiles)[i], ".png"), dpi = 300, width = 10, height = 10, units = "cm")
+
+  #Create path and file names for filtered samples"
+  filts[[i]] <- gsub("02-cutadapt/", "03-dada2/filtered/", files_exist[[i]])
+
+  #assign names to files
+  names(filts[[i]]) <- sample.names[[i]]
+
+  } else {
+
+  message(paste("No reads to process for", names(allfiles)[i], sep=" "))
+
+  }
+  }
+
+#Run filtering on reads:
+#Paired reads together and single reads separately
+
+  message("Filtering and Trimming paired reads based on parameter set in the config file")
+  out <- filterAndTrim(allfiles[[1]], filts[[1]], allfiles[[2]], filts[[2]],
+    truncLen = c(config$DADA2$filterAndTrim$Trunc_len_f,config$DADA2$filterAndTrim$Trunc_len_r),
+    truncQ=config$DADA2$filterAndTrim$TruncQ,
+    trimRight = config$DADA2$filterAndTrim$Trim_right,
+    trimLeft = config$DADA2$filterAndTrim$Trim_left,
+    maxLen = config$DADA2$filterAndTrim$maxLen,
+    minLen = config$DADA2$filterAndTrim$minLen,
+    maxN = config$DADA2$filterAndTrim$maxN,
+    minQ = config$DADA2$filterAndTrim$minQ,
+    maxEE = config$DADA2$filterAndTrim$MaxEE,
+    rm.phix = config$DADA2$filterAndTrim$Rm.phix,
+    orient.fwd = config$DADA2$filterAndTrim$orient.fwd,
+    matchIDs = config$DADA2$filterAndTrim$matchIDs,
+    id.sep = config$DADA2$filterAndTrim$id.sep,
+    id.field = config$DADA2$filterAndTrim$id.field,
+    compress = config$DADA2$filterAndTrim$compress,
+    multithread = config$DADA2$filterAndTrim$multithread,
+    n = config$DADA2$filterAndTrim$num,
+    OMP = config$DADA2$filterAndTrim$OMP,
+    verbose = config$DADA2$filterAndTrim$verbose)
+
+
+  #Write out to save the effect of filtering on the reads:
+  rownames(out) <- sample.names[[1]]
+  out=as.data.frame(out)
+  colnames(out)[2] <- "reads.out.paired"
+  stats_reads <- out
+  #write.table(out, paste0(outpath, "06-report/dada2/dada2_filtering_stats_paired_reads.txt"), row.names = TRUE, col.names = TRUE, quote = FALSE)
+
+  qualfiltsFs <- gsub(".png", "_filtered.png", quals[[1]])
+  qualfiltsRs <- gsub(".png", "_filtered.png", quals[[2]])
+
+  # Make quality profile plots.
+  message("Making quality plots of the filtered reads")
+  filts_passedF <-c()
+  filts_passedR <-c()
+  plot_list <- list()
+
+  for (j in 1:length(qualfiltsFs)) {
+    if (file.exists(filts[[1]][j])){
+      filts_passedF <- c(filts_passedF, filts[[1]][j])
+      dir.create(dirname(qualfiltsFs[j]), showWarnings = FALSE)
+      p <- plotQualityProfile(filts[[1]][j])
+      ggsave(qualfiltsFs[j], plot = p, dpi = 150, width = 10, height = 10, units = "cm")
+  }
+    if (file.exists(filts[[2]][j])){
+      filts_passedR <- c(filts_passedR, filts[[2]][j])
+      dir.create(dirname(qualfiltsRs[j]), showWarnings = FALSE)
+      q <- plotQualityProfile(filts[[2]][j])
+      ggsave(qualfiltsRs[j], plot = q, dpi = 150, width = 10, height = 10, units = "cm")
+  }
+}
+
+  print(plotQualityProfile(filts_passedF, aggregate=T))
+  ggsave(paste0(outpath, "06-report/dada2/aggregate_quality_profiles_paired_filtered_forward.png"), dpi = 300, width = 10, height = 10, units = "cm")
+  print(plotQualityProfile(filts_passedR, aggregate=T))
+  ggsave(paste0(outpath, "06-report/dada2/aggregate_quality_profiles_paired_filtered_reverse.png"), dpi = 300, width = 10, height = 10, units = "cm")
+
+
+# Same for single reads:
+
+message("Filtering and Trimming unpaired forward reads based on parameter set in the config file")
+if (length(files_exist[[3]])!=0){
+
+  out <- filterAndTrim(allfiles[[3]], filts[[3]],
+    truncLen = config$DADA2$filterAndTrim$Trunc_len_f,
+    truncQ=config$DADA2$filterAndTrim$TruncQ,
+    trimRight = config$DADA2$filterAndTrim$Trim_right,
+    trimLeft = config$DADA2$filterAndTrim$Trim_left,
+    maxLen = config$DADA2$filterAndTrim$maxLen,
+    minLen = config$DADA2$filterAndTrim$minLen,
+    maxN = config$DADA2$filterAndTrim$maxN,
+    minQ = config$DADA2$filterAndTrim$minQ,
+    maxEE = config$DADA2$filterAndTrim$MaxEE,
+    rm.phix = config$DADA2$filterAndTrim$Rm.phix,
+    orient.fwd = config$DADA2$filterAndTrim$orient.fwd,
+    matchIDs = config$DADA2$filterAndTrim$matchIDs,
+    id.sep = config$DADA2$filterAndTrim$id.sep,
+    id.field = config$DADA2$filterAndTrim$id.field,
+    compress = config$DADA2$filterAndTrim$compress,
+    multithread = config$DADA2$filterAndTrim$multithread,
+    n = config$DADA2$filterAndTrim$num,
+    OMP = config$DADA2$filterAndTrim$OMP,
+    verbose = config$DADA2$filterAndTrim$verbose)
+
+    #Write out to save the effect of filtering on the reads:
+    rownames(out) <- sample.names[[3]]
+    out=as.data.frame(out)
+    colnames(out) <- c("reads.in.forward.single", "reads.out.forward.single")
+    stats_reads=cbind(stats_reads, out[match(rownames(stats_reads), rownames(out)),])
+    #stats_reads$reads.out.forward.single = out$reads.out.forward.single[match(rownames(stats_reads), rownames(out))]
+    #write.table(out, paste0(outpath, "06-report/dada2/dada2_filtering_stats_unpaired_forward_reads.txt"), row.names = TRUE, col.names = TRUE, quote = FALSE)
+
+    qualfiltsFs_single <- gsub(".png", "_filtered.png", quals[[3]])
+
+    # Make quality profile plots.
+    message("Making quality plots of the filtered reads")
+    filts_passedF <-c()
+    plot_list <- list()
+
+    for (j in 1:length(qualfiltsFs_single)) {
+      if (file.exists(filts[[3]][j])){
+        filts_passedF <- c(filts_passedF, filts[[3]][j])
+        dir.create(dirname(qualfiltsFs_single[j]), showWarnings = FALSE)
+        p <- plotQualityProfile(filts[[3]][j])
+        ggsave(qualfiltsFs_single[j], plot = p, dpi = 150, width = 10, height = 10, units = "cm")
+    }
+    }
+
+    print(plotQualityProfile(filts_passedF, aggregate=T))
+    ggsave(paste0(outpath, "06-report/dada2/aggregate_quality_profiles_filtered_unpaired_forward.png"), dpi = 300, width = 10, height = 10, units = "cm")
+}
+
+
+message("Filtering and Trimming unpaired reverse reads based on parameter set in the config file")
+if (length(files_exist[[4]])!=0){
+
+  out <- filterAndTrim(allfiles[[4]], filts[[4]],
+    truncLen = config$DADA2$filterAndTrim$Trunc_len_r,
+    truncQ=config$DADA2$filterAndTrim$TruncQ,
+    trimRight = config$DADA2$filterAndTrim$Trim_right,
+    trimLeft = config$DADA2$filterAndTrim$Trim_left,
+    maxLen = config$DADA2$filterAndTrim$maxLen,
+    minLen = config$DADA2$filterAndTrim$minLen,
+    maxN = config$DADA2$filterAndTrim$maxN,
+    minQ = config$DADA2$filterAndTrim$minQ,
+    maxEE = config$DADA2$filterAndTrim$MaxEE,
+    rm.phix = config$DADA2$filterAndTrim$Rm.phix,
+    orient.fwd = config$DADA2$filterAndTrim$orient.fwd,
+    matchIDs = config$DADA2$filterAndTrim$matchIDs,
+    id.sep = config$DADA2$filterAndTrim$id.sep,
+    id.field = config$DADA2$filterAndTrim$id.field,
+    compress = config$DADA2$filterAndTrim$compress,
+    multithread = config$DADA2$filterAndTrim$multithread,
+    n = config$DADA2$filterAndTrim$num,
+    OMP = config$DADA2$filterAndTrim$OMP,
+    verbose = config$DADA2$filterAndTrim$verbose)
+
+    #Write out to save the effect of filtering on the reads:
+    rownames(out) <- sample.names[[4]]
+    out=as.data.frame(out)
+    colnames(out) <- c("reads.in.reverse.single", "reads.out.reverse.single")
+    stats_reads=cbind(stats_reads, out[match(rownames(stats_reads), rownames(out)),])
+    #stats_reads$reads.out.reverse.single = out$reads.out.reverse.single[match(rownames(stats_reads), rownames(out))]
+    #write.table(out, paste0(outpath, "06-report/dada2/dada2_filtering_stats_unpaired_reverse_reads.txt"), row.names = TRUE, col.names = TRUE, quote = FALSE)
+
+    qualfiltsRs_single <- gsub(".png", "_filtered.png", quals[[4]])
+
+    # Make quality profile plots.
+    message("Making quality plots of the filtered reads")
+    filts_passedR <-c()
+    plot_list <- list()
+
+    for (j in 1:length(qualfiltsRs_single)) {
+      if (file.exists(filts[[4]][j])){
+        filts_passedR <- c(filts_passedR, filts[[4]][j])
+        dir.create(dirname(qualfiltsRs_single[j]), showWarnings = FALSE)
+        p <- plotQualityProfile(filts[[4]][j])
+        ggsave(qualfiltsRs_single[j], plot = p, dpi = 150, width = 10, height = 10, units = "cm")
+    }
+    }
+
+    print(plotQualityProfile(filts_passedR, aggregate=T))
+    ggsave(paste0(outpath, "06-report/dada2/aggregate_quality_profiles_filtered_unpaired_reverse.png"), dpi = 300, width = 10, height = 10, units = "cm")
+}
+
+write.table(stats_reads, paste0(outpath, "06-report/dada2/dada2_filtering_stats.txt"), row.names = TRUE, col.names = TRUE, quote = FALSE)
+
+# Fix for https://github.com/tidyverse/ggplot2/issues/2787
+if (file.exists("Rplots.pdf")) {
+  file.remove("Rplots.pdf")
+}

--- a/workflow/scripts/Report_PacMAN_Pipeline.Rmd
+++ b/workflow/scripts/Report_PacMAN_Pipeline.Rmd
@@ -256,7 +256,7 @@ The quality profile of all analysed paired reads before trimming (Forward reads 
 
 ```{r, echo=FALSE, out.width="49%", out.height="20%",fig.cap="caption",fig.show='hold',fig.align='center'}
 
-knitr::include_graphics(c(paste0("../../results/", config$PROJECT, "/runs/", config$RUN,"/06-report/dada2/aggregate_quality_profiles_forward.png"), paste0("../../results/", config$PROJECT, "/runs/", config$RUN,"/06-report/dada2/aggregate_quality_profiles_reverse.png")))
+knitr::include_graphics(c(paste0("../../results/", config$PROJECT, "/runs/", config$RUN,"/06-report/dada2/aggregate_quality_profiles_filesForw.png"), paste0("../../results/", config$PROJECT, "/runs/", config$RUN,"/06-report/dada2/aggregate_quality_profiles_filesRev.png")))
 
 ```
 <br><br>
@@ -264,7 +264,18 @@ And after trimming it was:
 <br><br>
 ```{r, echo=FALSE, out.width="49%", out.height="20%",fig.cap="caption",fig.show='hold',fig.align='center'}
 
-knitr::include_graphics(c(paste0("../../results/", config$PROJECT, "/runs/", config$RUN,"/06-report/dada2/aggregate_quality_profiles_filtered_forward.png"), paste0("../../results/", config$PROJECT, "/runs/", config$RUN,"/06-report/dada2/aggregate_quality_profiles_filtered_reverse.png")))
+knitr::include_graphics(c(paste0("../../results/", config$PROJECT, "/runs/", config$RUN,"/06-report/dada2/aggregate_quality_profiles_paired_filtered_forward.png"), paste0("../../results/", config$PROJECT, "/runs/", config$RUN,"/06-report/dada2/aggregate_quality_profiles_paired_filtered_reverse.png")))
+
+```
+
+In case unpaired reads were kept after trimming and primer removal, quality profiles for unpaired reads can also be found in:
+
+```{r, echo=FALSE, out.width="49%", out.height="20%",fig.cap="caption",fig.show='hold',fig.align='center'}
+
+message(paste0("../../results/", config$PROJECT, "/runs/", config$RUN,"/06-report/dada2/aggregate_quality_profiles_filesForw_single.png"))
+message(paste0("../../results/", config$PROJECT, "/runs/", config$RUN,"/06-report/dada2/aggregate_quality_profiles_filesRev_single.png"))
+message(paste0("../../results/", config$PROJECT, "/runs/", config$RUN,"/06-report/dada2/aggregate_quality_profiles_filtered_unpaired_forward.png"))
+message(paste0("../../results/", config$PROJECT, "/runs/", config$RUN,"/06-report/dada2/aggregate_quality_profiles_fitlered_unpaired_reverse.png"))
 
 ```
 
@@ -272,7 +283,7 @@ knitr::include_graphics(c(paste0("../../results/", config$PROJECT, "/runs/", con
 
 The following step of the dada2 pipeline was define the ASVs from these trimmed reads.
 <br>
-First error rates were learned for both forward and reverse reads separately with the following command:
+First error rates were learned for both forward and reverse paired reads separately as well as any unpaired remaining reads which survived filtering, with the following command:
 
 ```{r, echo=F}
 cat("learnErrors(filtFs, multithread = ",config$DADA2$learnERRORS$multithread,", nbases = ",config$DADA2$learnERRORS$nbases,", randomize = ",config$DADA2$learnERRORS$randomize,",MAX_CONSIST = ",config$DADA2$learnERRORS$MAX_CONSIST,", OMEGA_C = ",config$DADA2$learnERRORS$OMEGA_C,", verbose = ",config$DADA2$learnERRORS$verbose,")", sep="")
@@ -299,7 +310,7 @@ cat("dada(derepFs, err = errF, selfConsist = ",config$DADA2$dada$selfConsist,", 
   multithread = ",config$DADA2$learnERRORS$multithread,")", sep="")
 ```
 
-Sequence pairs were combined using:
+In case reads were overlapping (include merge in the config file), sequence pairs were combined using:
 
 ```{r, echo=F}
 cat("mergePairs(dadaFs, derepFs, dadaRs, derepRs,
@@ -307,6 +318,10 @@ cat("mergePairs(dadaFs, derepFs, dadaRs, derepRs,
   propagateCol = ",config$DADA2$mergePairs$propagateCol,", justConcatenate = ",config$DADA2$mergePairs$justConcatenate,", trimOverhang = ",config$DADA2$mergePairs$trimOverhang,")", sep="")
 
 ```
+If returnRejects was selected, also the returned unpaired sequences were kept in the final tables.
+Otherwise, the dereplicated sequences were kept without merging.
+Also any sequences unpaired forward or reverse sequences were added to the sequence tables at this stage.
+All single reverse sequences (unpaired either in trimmomatic or here, or if pairs were not merged), were reverse complemented for the bowtie2 algorithm.
 
 And finally, chimeras were removed with:
 

--- a/workflow/scripts/Report_PacMAN_Pipeline.Rmd
+++ b/workflow/scripts/Report_PacMAN_Pipeline.Rmd
@@ -182,7 +182,7 @@ rownames(cutResults)[i]=sample_ids[i]
 
 kable(cutResults)
 
-cutResults_Percentage=round(cutResults[,c(2:3)]/cutResults$TotalReadPairsProcessed*100, digits=2)
+cutResults_Percentage=round(cutResults[,c("ReadwithPrimer","ReadsWritten")]/cutResults$TotalReadPairsProcessed*100, digits=2)
 cutResults_Percentage$BasePairsWritten=round(cutResults$BasePairsWritten/cutResults$BasePairsProcessed*100, digits=2)
 kable(cutResults_Percentage)
 ```
@@ -216,7 +216,7 @@ rownames(cutResults)[i]=sample_ids[i]
 
 kable(cutResults)
 
-cutResults_Percentage=round(cutResults[,c(2:3)]/cutResults$TotalReadPairsProcessed*100, digits=2)
+cutResults_Percentage=round(cutResults[,c("ReadwithPrimer","ReadsWritten")]/cutResults$TotalReadPairsProcessed*100, digits=2)
 cutResults_Percentage$BasePairsWritten=round(cutResults$BasePairsWritten/cutResults$BasePairsProcessed*100, digits=2)
 kable(cutResults_Percentage)
 


### PR DESCRIPTION
Fixes for errors, and how parameters are read into the R-scripts: now directly from the config-file. Major changes to the dada2 pipe, by adding the analysis of unpaired reads from trimmomatic-cutadapt, as well as unpaired reads that were not merged during merge-pairs. These unmerged paired reads are concatenated instead. It is also possible to run the pipeline without merging (mergePaires:include in config file), but so far only for paired sequencing reads. 