### PR TITLE
Upgraded biostrings and dada2

### DIFF
--- a/workflow/envs/dada2.yaml
+++ b/workflow/envs/dada2.yaml
@@ -5,7 +5,7 @@ dependencies:
  - r-base=4.0.3
  - r-matrix=1.3-2
  - r-reshape2=1.4.4
- - bioconductor-dada2=1.18.0
+ - bioconductor-dada2=1.22.0
  - r-ggplot2=3.3.3
  - r-yaml=2.2.1
  - r-dplyr=1.0.7

--- a/workflow/envs/worrms.yaml
+++ b/workflow/envs/worrms.yaml
@@ -8,4 +8,4 @@ dependencies:
  - r-stringr=1.4.0
  - r-dplyr=1.0.7
  - r-tidyr=1.1.3
- - bioconductor-biostrings=2.58.0
+ - bioconductor-biostrings=2.62.0


### PR DESCRIPTION
@SSuominen1 I had two instances of `ResolvePackageNotFound` which were solved by upgrading `bioconductor-biostrings` and `bioconductor-dada2`. Can you check if the new versions are fine to use?