### PR TITLE
Taxon matching improvements

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -16,7 +16,7 @@ config_path = workflow.overwrite_configfiles[0] if workflow.overwrite_configfile
 PROJECT = config["PROJECT"]
 RUN = config["RUN"]
 DATABASE = config["DATABASE"]["name"]
-CUTOFF = config["TAXONOMY"]["blca_identity_cutoff"]
+CUTOFF = config["TAXONOMY"]["blca_confidence_cutoff"]
 sample_set = pd.read_csv(config["SAMPLE_SET"], header=0)
 samples = pd.unique(sample_set['sample-id'])
 
@@ -436,7 +436,7 @@ rule filter_taxa:
     python ./workflow/scripts/reformat_summary_for_r.py \
     {output.o1} \
     {output.o2} \
-    {config[TAXONOMY][blca_identity_cutoff]}"
+    {config[TAXONOMY][blca_confidence_cutoff]}"
 
 
 # The remaining unknown sequences from blca are blasted against nt, so that all possible public information is checked.

--- a/workflow/scripts/Report_PacMAN_Pipeline.Rmd
+++ b/workflow/scripts/Report_PacMAN_Pipeline.Rmd
@@ -412,7 +412,7 @@ cat("python ./workflow/scripts/blca_from_bowtie.py  -i alignment.sam  -r ", conf
 The provided `cutoff` was then used to filter the blca output for reliable taxonomic assignments:
 
 ```{r, echo=F}
-cat("python ./workflow/scripts/reformat_summary_for_r.py blca.output tax.table   ", config$TAXONOMY$blca_identity_cutoff, sep = "")
+cat("python ./workflow/scripts/reformat_summary_for_r.py blca.output tax.table   ", config$TAXONOMY$blca_confidence_cutoff, sep = "")
 ```
 
 
@@ -424,8 +424,8 @@ The used command was:
 ```{r, echo=F}
 if (config$BLAST$include) {
 
-cat("blastn -query  results/", config$PROJECT, "/runs/", config$RUN, "/04-taxonomy/blca/", config$DATABASE$name, "_unclassified-seqs_cutoff", config$TAXONOMY$blca_identity_cutoff, ".fna", 
-    " -out " , "results/", config$PROJECT, "/runs/", config$RUN, "/04-taxonomy/blast/", config$DATABASE$name, "_unclassified_blast_results_cutoff", config$TAXONOMY$blca_identity_cutoff, ".tab", 
+cat("blastn -query  results/", config$PROJECT, "/runs/", config$RUN, "/04-taxonomy/blca/", config$DATABASE$name, "_unclassified-seqs_cutoff", config$TAXONOMY$blca_confidence_cutoff, ".fna", 
+    " -out " , "results/", config$PROJECT, "/runs/", config$RUN, "/04-taxonomy/blast/", config$DATABASE$name, "_unclassified_blast_results_cutoff", config$TAXONOMY$blca_confidence_cutoff, ".tab", 
     " -outfmt 6 -perc_indentity ", config$BLAST$perc_identity, " ", "config$BLAST$database", sep = "")
 
 } else {
@@ -442,8 +442,8 @@ A number of parameters can be chosen for the basta-lca analysis. The following c
 if (config$BLAST$include) {
 
 cat("basta sequence -p ", config$BLAST$portion_of_hits, " -i ", config$BLAST$percent_identity, " -l ", config$BLAST$alignment_length, " -e ", config$BLAST$e_value, " -n ", config$BLAST$max_hits, " -m ", config$BLAST$min_hits, " -d ", config$BLAST$tax_db,
- "  results/", config$PROJECT, "/runs/", config$RUN, "/04-taxonomy/blast/", config$DATABASE$name, "_unclassified_blast_results_cutoff", config$TAXONOMY$blca_identity_cutoff, ".tab   results/", 
- config$PROJECT, "/runs/", config$RUN, "/04-taxonomy/blast/", config$DATABASE$name, "_unclassified_blast_results_lca_cutoff", config$TAXONOMY$blca_identity_cutoff, ".tab gb", sep="")
+ "  results/", config$PROJECT, "/runs/", config$RUN, "/04-taxonomy/blast/", config$DATABASE$name, "_unclassified_blast_results_cutoff", config$TAXONOMY$blca_confidence_cutoff, ".tab   results/", 
+ config$PROJECT, "/runs/", config$RUN, "/04-taxonomy/blast/", config$DATABASE$name, "_unclassified_blast_results_lca_cutoff", config$TAXONOMY$blca_confidence_cutoff, ".tab gb", sep="")
 
 } else {
 

--- a/workflow/scripts/format_for_dwc_new.R
+++ b/workflow/scripts/format_for_dwc_new.R
@@ -1,6 +1,5 @@
 # Written by Saara Suominen (saara.suominen.work@gmail.com)
 # for OBIS and PacMAN
-#Last update 21.6.2021
 
 library("stringr")
 library("phyloseq")
@@ -8,7 +7,9 @@ library("dplyr")
 library("xml2")
 library("yaml")
 
+# Parse arguments
 args <- commandArgs(trailingOnly = T)
+message("args <- ", capture.output(dput(args))) # output for debugging
 
 outpath <- args[1]
 tax_file_path <- args[3]
@@ -75,7 +76,7 @@ phydata <- phyloseq::merge_phyloseq(phydata, Rep_seqs)
 phydata
 
 # Save the phyloseq rdata object for easier access in the future
-print("Saving the phyloseq -table to an Rdata object, for ease of access for data analysis later")
+print("Saving the phyloseq table to an Rdata object, for ease of access for data analysis later")
 print("The object can be loaded with readRDS, while the phyloseq package and library is loaded")
 print(paste("The saved object can be found here: ", outpath, "phyloseq_object.rds", sep = ""))
 saveRDS(phydata, paste0(outpath, "phyloseq_object.rds"))
@@ -124,14 +125,14 @@ get_dwc_fields <- function(spec_url) {
     xml_attr(attr = "name")
 }
 
-spec_occurrence <- "https://rs.gbif.org/core/dwc_occurrence_2020-07-15.xml"
+spec_occurrence <- "https://rs.gbif.org/core/dwc_occurrence_2022-02-02.xml"
 occurrence_table_fields <- get_dwc_fields(spec_occurrence)
 
 spec_dna <- "https://rs.gbif.org/extension/gbif/1.0/dna_derived_data_2021-07-05.xml"
 DNA_extension_fields <- get_dwc_fields(spec_dna)
 
 occurrence_table <- phydf_present[,colnames(phydf_present) %in% occurrence_table_fields]
-DNA_derived_data_extension <- phydf_present[,colnames(phydf_present) %in% c('occurrenceID', DNA_extension_fields)]
+DNA_derived_data_extension <- phydf_present[,colnames(phydf_present) %in% c("occurrenceID", DNA_extension_fields)]
 
 write.table(occurrence_table, paste0(outpath, "Occurence_table.csv"), sep = "\t", row.names = FALSE, col.names = TRUE, quote = FALSE, na = "")
 write.table(DNA_derived_data_extension, paste0(outpath, "DNA_extension_table.csv"), sep = "\t", row.names = FALSE, col.names = TRUE, quote = FALSE, na = "")

--- a/workflow/scripts/format_for_dwc_new.R
+++ b/workflow/scripts/format_for_dwc_new.R
@@ -11,16 +11,21 @@ library("yaml")
 args <- commandArgs(trailingOnly = T)
 
 outpath <- args[1]
+tax_file_path <- args[3]
+otu_file_path <- args[2]
+rep_seqs_path <- args[4]
+sample_file_path <- args[5]
+config_path <- args[6]
 
 # LOAD data (this will be done from input later on)
 
-tax_file <- read.csv(args[3], sep = "\t", header = T, row.names = 1)
-otu_file <- read.csv(args[2], sep = "\t", header = T, row.names = 1, check.names = F)
-Rep_seqs <- Biostrings::readDNAStringSet(args[4])
-sample_file <- read.csv(args[5], sep = ";", header = T, row.names = 1)
-config <- read_yaml(args[6])
+tax_file <- read.csv(tax_file_path, sep = "\t", header = T, row.names = 1)
+otu_file <- read.csv(otu_file_path, sep = "\t", header = T, row.names = 1, check.names = F)
+Rep_seqs <- Biostrings::readDNAStringSet(rep_seqs_path)
+sample_file <- read.csv(sample_file_path, sep = ";", header = T, row.names = 1)
+config <- read_yaml(config_path)
 
-# Add checks!
+# TODO: Add checks!
 # 1. Make sure that the values are given
 # 2. Make sure that the sample names in the otu-file (the original sample table), and the sample_data match!
 # 3. Make sure the required fields are not empty
@@ -101,15 +106,10 @@ phydf$occurrenceID <- paste(phydf$OTU, phydf$Sample, sep = "_")
 # Change names where necessary
 #names(phydf[names(phydf)=="lastvalue"])="ScientificName"
 phydf <- phydf %>%
-          rename(
-              scientificName = lastvalue,
-              organismQuantity = Abundance,
-              scientificNameID = lsid
-            )
-            # %>%
-            # add_column(organismQuantityType = "DNA Sequence reads") %>%
-            # add_column(sampleSizeUnit = "DNA Sequence reads")
-
+  rename(organismQuantity = Abundance)
+  # %>%
+  # add_column(organismQuantityType = "DNA Sequence reads") %>%
+  # add_column(sampleSizeUnit = "DNA Sequence reads")
 
 # Remove 0 Abundance data (not valuable for us)
 phydf_present <- phydf[phydf$organismQuantity > 0,]

--- a/workflow/scripts/get_lsids.R
+++ b/workflow/scripts/get_lsids.R
@@ -143,21 +143,6 @@ match_name <- function(name) {
 # Taxon names across all ranks
 tax_names <- taxmat %>% select(!!!RANKS) %>% unlist() %>% na.omit() %>% unique() %>% sort()
 matches <- sapply(tax_names, match_name)
-lsid_map <- lapply(tax_names, function(x) {
-  list(lsid = matches[[x]]$lsid, scientificname =  matches[[x]]$scientificname, rank =  matches[[x]]$rank)
-})
-names(lsid_map) <- tax_names
-
-# lookup_lsid <- function(input) {
-#   lsids <- sapply(input, function(x) { lsid_map[[x]] })
-#   lsids[sapply(lsids, is.null)] <- NA
-#   return(unlist(lsids))
-# }
-
-# lsid_table <- taxmat %>%
-#   select(!!!RANKS) %>%
-#   mutate(across(everything(), lookup_lsid))
-# best_column_index <- max.col(!is.na(lsid_table), "last")
 
 taxmat$scientificName <- NA
 taxmat$scientificNameID <- NA
@@ -166,23 +151,23 @@ for (i in 1:nrow(taxmat)) {
 
   lsids <- taxmat[i, RANKS] %>%
     as.character() %>%
-    sapply(function(x) { lsid_map[[x]]$lsid }) %>%
+    sapply(function(x) { matches[[x]]$lsid }) %>%
     sapply(function(x) { ifelse(is.null(x), NA, x) }) %>%
     unlist()
   if (all(is.na(lsids))) next
 
   most_specific_name <- taxmat[i, max(which(!is.na(lsids)))]
+  scientificnameid <- matches[[most_specific_name]]$lsid
 
-  scientificname <- lsid_map[[most_specific_name]]$scientificname
-  scientificnameid <- lsid_map[[most_specific_name]]$lsid
-  rank <- lsid_map[[most_specific_name]]$rank
-
-  if (!is.na(scientificnameid)) {
-      taxmat$scientificName[i] <- scientificname
-      taxmat$scientificNameID[i] <- scientificnameid
-      taxmat$taxonRank[i] <- tolower(rank)
-  }
-
+    taxmat$scientificName[i] <- matches[[most_specific_name]]$scientificname
+    taxmat$scientificNameID[i] <- matches[[most_specific_name]]$lsid
+    taxmat$taxonRank[i] <- tolower(matches[[most_specific_name]]$rank)
+    taxmat$kingdom[i] <- matches[[most_specific_name]]$kingdom
+    taxmat$phylum[i] <- matches[[most_specific_name]]$phylum
+    taxmat$class[i] <- matches[[most_specific_name]]$class
+    taxmat$order[i] <- matches[[most_specific_name]]$order
+    taxmat$family[i] <- matches[[most_specific_name]]$family
+    taxmat$genus[i] <- matches[[most_specific_name]]$genus
 }
 
 # Add Biota LSID in case there is no last value

--- a/workflow/scripts/get_lsids.R
+++ b/workflow/scripts/get_lsids.R
@@ -73,7 +73,7 @@ taxmat <- cleaned %>%
   bind_rows() %>%
   as.data.frame() %>%
   select(!!!RANKS) %>%
-  mutate(identificationRemarks = tax_file$sum.taxonomy)
+  mutate(identificationRemarks = tax_file$taxonomy_confidence)
 
 row.names(taxmat) <- tax_file$rowname
 

--- a/workflow/scripts/get_lsids.R
+++ b/workflow/scripts/get_lsids.R
@@ -1,6 +1,5 @@
 # Written by Saara Suominen (saara.suominen.work@gmail.com)
 # for OBIS and PacMAN
-#Last update 21.6.2021
 
 library(worrms)
 library(stringr)
@@ -8,7 +7,15 @@ library(Biostrings)
 library(dplyr)
 library(tidyr)
 
+RANKS <- c("kingdom", "phylum", "class", "order", "family", "genus", "species")
+PIPELINE <- "bowtie2;2.4.4;ANACAPA-blca;2021"
+BLAST_VERSION <- "blastn;2.12.0"
+BLAST_DB <- "NCBI-nt;"
+REF_DB_PATTERN <- "identity_filtered/\\s*(.*?)\\s*_blca_tax_table"
+
+# Parse arguments
 args <- commandArgs(trailingOnly = T)
+message("args <- ", capture.output(dput(args))) # output for debugging
 
 outpath <- args[1]
 tax_file_path <- args[2]
@@ -20,11 +27,16 @@ if (length(args) == 5) {
     basta_file_path <- NULL
 }
 
-RANKS <- c("kingdom", "phylum", "class", "order", "family", "genus", "species")
-
 ########################### 1. Read input files  ################################################################################################################
 
-tax_file <- read.csv(tax_file_path, sep = "\t", header = T)
+tax_file <- read.csv(tax_file_path, sep = "\t", header = T) %>%
+  rename("verbatimIdentification" = "taxonomy_confidence")
+# Add annotation pipeline and reference database
+tax_file$otu_seq_comp_appr <- PIPELINE
+result <- regmatches(tax_file_path, regexec(REF_DB_PATTERN, tax_file_path))
+otu_db <- result[[1]][2]
+tax_file$otu_db <- otu_db
+
 rep_seqs <- Biostrings::readDNAStringSet(rep_seqs_path)
 
 # If blast was performed on the unknown sequences:
@@ -32,6 +44,11 @@ if (!is.null(basta_file_path)) {
   if (file.size(basta_file_path) > 0) {
     message("0. Results of Blast annotation read")
     basta_file <- read.csv(basta_file_path, sep = "\t", header = F)
+    colnames(basta_file) <- c("rowname", "sum.taxonomy")
+    basta_file$verbatimIdentification <- basta_file$sum.taxonomy
+    # Add annotation pipeline and reference database
+    basta_file$otu_seq_comp_appr <- BLAST_VERSION
+    basta_file$otu_db <- paste0(BLAST_DB, blast_date)
   }
 }
 
@@ -39,90 +56,56 @@ if (!is.null(basta_file_path)) {
 
 message("1. Modify tax table for taxonomic ranks, and find all possible worms ids (using worrms package)")
 
-clean_taxonomy_prefixed <- function(taxa) {
-  taxa <- taxa[taxa != "" & taxa != "NA" & taxa != "nan"]
-  if (length(taxa) == 0) {
-    return(list(kingdom = NA))
-  }
-  parts <- str_match(taxa, "([a-z]+)__(.*)_[0-9]")
-  ranks <- recode(parts[,2], "k" = "kingdom", "p" = "phylum", "c" = "class", "o" = "order", "f" = "family", "g" = "genus", "s" = "species")
-  taxon_names <- as.list(parts[,3])
-  names(taxon_names) <- ranks
-  return(taxon_names)
-}
-
+# Clean set of taxon names into taxonomy as a named list
 clean_taxonomy <- function(taxa) {
-  if (length(taxa) == 0) {
-    return(list(kingdom = NA))
+  if (all(str_detect(taxa, "([a-z]+)__(.*)_[0-9]"))) {
+    taxa <- taxa[taxa != "" & taxa != "NA" & taxa != "nan"]
+    if (length(taxa) == 0) {
+      return(list(kingdom = NA))
+    }
+    parts <- str_match(taxa, "([a-z]+)__(.*)_[0-9]")
+    ranks <- recode(parts[,2], "k" = "kingdom", "p" = "phylum", "c" = "class", "o" = "order", "f" = "family", "g" = "genus", "s" = "species")
+    taxon_names <- as.list(parts[,3])
+    names(taxon_names) <- ranks
+    return(taxon_names)
+  } else {
+    if (length(taxa) == 0) {
+      return(list(kingdom = NA))
+    }
+    taxa[taxa %in% c("", "NA", "nan", "unknown", "Unknown")] <- NA
+    taxon_names <- setNames(as.list(taxa), RANKS[1:length(taxa)])
+    return(taxon_names)
   }
-  taxa[taxa %in% c("", "NA", "nan")] <- NA
-  taxon_names <- setNames(as.list(taxa), RANKS[1:length(taxa)])
-  return(taxon_names)
 }
 
-taxonomies <- str_split(tax_file$sum.taxonomy, ";")
-
-if (grepl("MIDORI_UNIQ", tax_file_path, fixed = TRUE, ignore.case = TRUE)) {
-  # Move names to the appropriate columns if using the MIDORI database
-  cleaned <- lapply(taxonomies, clean_taxonomy_prefixed)
-} else {
-  cleaned <- lapply(taxonomies, clean_taxonomy)
+if (exists("basta_file")) {
+  # Remove ASVs present in basta file from tax file
+  tax_file <- tax_file %>% filter(!rowname %in% basta_file$rowname)
+  # Merge
+  tax_file <- bind_rows(tax_file, basta_file)
 }
+
+taxonomies <- str_split(str_replace(tax_file$sum.taxonomy, ";+$", ""), ";")
+cleaned <- lapply(taxonomies, clean_taxonomy)
 
 taxmat <- cleaned %>%
   bind_rows() %>%
   as.data.frame() %>%
   select(!!!RANKS) %>%
-  mutate(identificationRemarks = tax_file$taxonomy_confidence)
+  mutate(verbatimIdentification = tax_file$taxonomy_confidence)
 
 row.names(taxmat) <- tax_file$rowname
 
-# TODO: remove
-# Collect the highest known taxonomic value to the last column
-# taxmat$lastvalue <- as.matrix(taxmat)[cbind(seq(1, nrow(taxmat)), max.col(!is.na(taxmat), "last"))]
-
-# Add information on the classification approach
-# TODO: remove hard coding
-taxmat$otu_seq_comp_appr <- "bowtie2;2.4.4;ANACAPA-blca;2021"
-
-# Get otu_db name from the input filename
-pattern <- "identity_filtered/\\s*(.*?)\\s*_blca_tax_table"
-result <- regmatches(tax_file_path, regexec(pattern, tax_file_path))
-taxmat$otu_db <- result[[1]][2]
-
-# If Blast was performed on unknown sequences and gave results after lca
-if (exists("basta_file")) {
-  message("1.1 Adding Blast results to taxonomic table")
-  colnames(basta_file) <- c("rowname", "sum.taxonomy")
-  taxmat2 <- separate(basta_file, "sum.taxonomy", into = RANKS, sep = ";")
-  taxmat2[taxmat2 == ""] <- NA
-  taxmat2$species <- gsub("_", " ", taxmat2$species)
-  taxmat2$lastvalue <- as.matrix(taxmat2)[cbind(seq(1, nrow(taxmat2)), max.col(!is.na(taxmat2), "last"))]
-  # Add also the fields that separate the otu assignment methods
-  # Note: read these from the config file?
-  # TODO: remove hard coding
-  taxmat2$otu_seq_comp_appr <- "blastn;2.12.0"
-  taxmat2$otu_db <- paste0("NCBI-nt;", blast_date)
-  rownames(taxmat2) <- taxmat2$rowname
-  taxmat2 <- subset(taxmat2, select = -c(rowname))
-
-  # Combine this taxmat to the original one
-  # At the moment the unknowns are there twice! So first remove duplicates before you combine them
-  taxmat <- taxmat[!(rownames(taxmat) %in% rownames(taxmat2)),]
-  taxmat <- rbind(taxmat, taxmat2)
-}
-
 # Add possible remaining unknowns to the taxmat based on asvs in the rep_seqs (keep all ASVs in the final dataset)
-rep_seqs_unknown <- names(rep_seqs[!names(rep_seqs) %in% row.names(taxmat),])
-rn <- row.names(taxmat)
-taxmat[nrow(taxmat) + seq_along(rep_seqs_unknown), ] <- NA 
-row.names(taxmat) <- c(rn, rep_seqs_unknown)
-# Fill the original database values on the otu_seq_comp_appr and otu_db for the unknown sequences as well
-taxmat[is.na(taxmat$otu_seq_comp_appr), "otu_seq_comp_appr"] <- "bowtie2;2.4.4;ANACAPA-blca;2021"
-taxmat[is.na(taxmat$otu_db), "otu_db"] <- taxmat[1,"otu_db"]
+rep_seqs_unknown <- names(rep_seqs[!names(rep_seqs)%in%row.names(taxmat),])
+taxmat_unknown <- data.frame(
+  otu_seq_comp_appr = rep(PIPELINE, length(rep_seqs_unknown)),
+  otu_db = rep(otu_db, length(rep_seqs_unknown))
+)
+row.names(taxmat_unknown) <- rep_seqs_unknown
+taxmat <- bind_rows(taxmat, taxmat_unknown)
 
-# TODO: failing with rate limit, submit in batches
-
+# TODO: failing with rate limit, submit in batches with at least version 0.4.3 of worrms (https://anaconda.org/conda-forge/r-worrms)
 match_name <- function(name) {
   lsid <- tryCatch({
     res <- wm_records_names(name, marine_only = FALSE)
@@ -172,44 +155,19 @@ for (i in 1:nrow(taxmat)) {
 
 # Add Biota LSID in case there is no last value
 # Kingdom is used as taxonRank so that "Biota" is also recognized correctly by GBIF
-
 taxmat$scientificName[is.na(taxmat$scientificName)] <- "Biota"
 taxmat$taxonRank[is.na(taxmat$scientificNameID)] <- "kingdom"
 taxmat$scientificNameID[is.na(taxmat$scientificNameID)] <- "urn:lsid:marinespecies.org:taxname:1"
 
 # Names not in WoRMS
-
 names_not_in_worms <- names(matches)[sapply(matches, is.null)]
 message("Number of species names not recognized in WORMS: ", length(names_not_in_worms))
-
-# TODO: disabled for now, matching already happens at all levels
-# Some of these are common contaminants (e.g. Homo sapiens, Canis lupus)
-# Some of these are not marine species (e.g. insects), that could be found with terrestrial matches
-# Some have a higher taxonomy that can be found in the database
-# Check at genus level:
-# genus_names <- unique(na.omit(taxmat$genus[is.na(taxmat$lsid)]))
-# genus_matches <- sapply(genus_names, match_name)
-# missing_lsids <- is.na(taxmat$lsid)
-# for (i in 1:nrow(taxmat)) {
-#   if (is.na(taxmat$lsid[i]) & !is.na(taxmat$genus[i]) & !is.null(genus_matches[[taxmat$genus[i]]])) {
-#     taxmat$lsid[i] <- genus_matches[[taxmat$genus[i]]]$lsid
-#     taxmat$taxonRank[i] <- "genus"
-#   }
-# }
-# This way unknowns decreases. However, these values should be checked for possible addition to WoRMS?
-# Will require manual inspection
-# genera_not_in_worms <- names(genus_matches)[sapply(genus_matches, is.null)]
-# message("Number of genus names not recognized in WORMS: ", length(genera_not_in_worms))
-# message("These taxa can be found in the table: ", outpath, "Taxa_not_in_worms.csv")
-# not_in_worms <- taxmat[is.na(taxmat$lsid),]
 
 # Add sequence to the tax_table slot (linked to each asv)
 taxmat$DNA_sequence <- as.character(rep_seqs[row.names(taxmat)])
 
 # Write table of unknown names to make manual inspection easier:
-
 write.table(names_not_in_worms, paste0(outpath, "Taxa_not_in_worms.csv"), sep = "\t", row.names = TRUE, col.names = TRUE, quote = FALSE, na = "")
 
 # Write tax table
-#taxmat <- apply(taxmat,2,as.character)
 write.table(taxmat, paste0(outpath, "Full_tax_table_with_lsids.csv"), sep = "\t", row.names = TRUE, col.names = TRUE, quote = FALSE, na = "")

--- a/workflow/scripts/get_lsids.R
+++ b/workflow/scripts/get_lsids.R
@@ -92,7 +92,7 @@ taxmat <- cleaned %>%
   bind_rows() %>%
   as.data.frame() %>%
   select(!!!RANKS) %>%
-  mutate(verbatimIdentification = tax_file$taxonomy_confidence)
+  mutate(verbatimIdentification = tax_file$verbatimIdentification)
 
 row.names(taxmat) <- tax_file$rowname
 

--- a/workflow/scripts/reformat_summary_for_r.py
+++ b/workflow/scripts/reformat_summary_for_r.py
@@ -6,6 +6,15 @@ import argparse
 import shutil
 
 
+def summarize_taxonomy(full_taxonomy, confidences):
+    full_taxonomy = full_taxonomy.rstrip(';')
+    confidences = confidences.rstrip(';')
+    taxonomy_components = [f.split(":") for f in full_taxonomy.split(";")]
+    confidence_components = [c.split(":") for c in confidences.split(";")]
+    summary = ";".join([":".join((t[0], t[1], confidence_components[i][1])) for i, t in enumerate(taxonomy_components)])
+    return summary
+
+
 def truncate_taxonomy(full_taxonomy, confidences, cutoff):
     # the taxonomy and confidences may have an extra semicolon at the end
     full_taxonomy = full_taxonomy.rstrip(';')
@@ -26,7 +35,7 @@ def reformat_summary(summary_file_name, output_file_name, cutoff):
     previous_header = summary[0].strip().split('\t')
     taxonomy_index = previous_header.index('taxonomy')
     confidence_index = previous_header.index('taxonomy_confidence')
-    header = previous_header[:taxonomy_index] + ['sum.taxonomy']
+    header = previous_header[:taxonomy_index] + ['sum.taxonomy', 'taxonomy_confidence']
     output = open(output_file_name + '.tmp', 'w')
     output.write('\t'.join(header) + '\n')
 
@@ -36,9 +45,11 @@ def reformat_summary(summary_file_name, output_file_name, cutoff):
         if ':' in fields[taxonomy_index]:
             taxonomy = truncate_taxonomy(fields[taxonomy_index], fields[confidence_index], cutoff)
             output_taxonomy = [taxonomy.get(level, '') for level in output_levels]
+            taxonomy_summary = summarize_taxonomy(fields[taxonomy_index], fields[confidence_index])
         else:
             output_taxonomy = ''
-        fields_to_write = fields[:taxonomy_index] + [';'.join(output_taxonomy)]
+            taxonomy_summary = ''
+        fields_to_write = fields[:taxonomy_index] + [';'.join(output_taxonomy)] + [taxonomy_summary]
         output.write('\t'.join(fields_to_write) + '\n')
 
     output.close()


### PR DESCRIPTION
@SSuominen1 This is a proposal to change how taxon matching works. The current version matches species and genus names with WoRMS to populate `scientificNameID`. This update matches names at all taxonomic levels and populates all taxonomic fields with the most specific WoRMS match. This ensures that the taxonomy in the output if fully aligned with WoRMS. The original lineage goes into `verbatimIdentification`.